### PR TITLE
Replace TellSize with SizedFlatten

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 use curve25519_dalek::scalar::Scalar;
 
 #[derive(Clone)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct ScalarExp {
     x: Scalar,
     next_x: Scalar,
@@ -27,37 +28,61 @@ pub fn exp_iter(x: Scalar) -> ScalarExp {
     ScalarExp { x, next_x }
 }
 
-#[derive(Clone)]
-pub struct TellSize<I> {
-    size: usize,
-    iter: I,
+#[derive(Clone, Debug)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct SizedFlatten<I, U> {
+    outer: I,
+    inner: Option<U>,
 }
 
-pub trait IntoTellSize {
-    #[inline]
-    fn tell_size(self, size: usize) -> TellSize<Self>
-    where
-        Self: Sized + Iterator,
-    {
-        TellSize { iter: self, size }
-    }
-}
-
-impl<I: ?Sized> IntoTellSize for I where I: Iterator {}
-
-impl<I> Iterator for TellSize<I>
+impl<I, U> SizedFlatten<I, U>
 where
     I: Iterator,
 {
-    type Item = I::Item;
+    pub fn new(iter: I) -> SizedFlatten<I, U> {
+        SizedFlatten {
+            outer: iter,
+            inner: None,
+        }
+    }
+}
+
+impl<I, U> Iterator for SizedFlatten<I, U>
+where
+    I: Clone + Iterator,
+    U: Clone + Iterator,
+    I::Item: IntoIterator<IntoIter = U, Item = U::Item>,
+{
+    type Item = U::Item;
 
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
-        self.iter.next()
+    fn next(&mut self) -> Option<U::Item> {
+        loop {
+            if let Some(ref mut i) = self.inner {
+                match i.next() {
+                    None => self.inner = None,
+                    v @ Some(_) => return v,
+                }
+            }
+            match self.outer.next() {
+                None => return None,
+                Some(i) => self.inner = Some(i.into_iter()),
+            }
+        }
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.size, Some(self.size))
+        let (mut lo, mut hi) = self.inner.as_ref().map_or((0, Some(0)), U::size_hint);
+        for (l, h) in self.outer.clone().map(|i| i.into_iter().size_hint()) {
+            lo += l;
+            if let Some(sum) = hi {
+                hi = match h {
+                    Some(val) => Some(sum + val),
+                    None => None,
+                };
+            }
+        }
+        (lo, hi)
     }
 }


### PR DESCRIPTION
This removes the tell_size() hack, in favor of a new SizedFlatten iterator. This iterator reports much more accurate size_hints, at the expense of cloning iterators.

Initial performance advantage seems significant, but more review and testing is required to confirm there are no unintended side effects. One particular concern, is evaluating cloned iterators may cause side-effects depending which closures exist in the iterator chains. I don't believe this is the case, but it requires consideration.

Resolves https://github.com/cargodog/arcturus/issues/24